### PR TITLE
Ported the Frameworks page to Sphinx

### DIFF
--- a/frameworks.rst
+++ b/frameworks.rst
@@ -34,6 +34,11 @@ links!
     and middleware.
 `Django <http://www.djangoproject.com/>`_
     Includes support for WSGI servers
+`Flask <http://flask.pocoo.org/>`_
+    Flask is a microframework for Python based on Werkzeug, Jinja 2
+    and good intentions.
+
+    It inherits its high WSGI usage and compliance from Werkzeug.
 `notmm <https://bitbucket.org/erob/notmm/overview>`_
     The notmm toolkit is a fork of Django that doesn't get in your
     way. Features includes improved WSGI support (Paste), SQLAlchemy,


### PR DESCRIPTION
- Ported the document itself
- Fixed a few dead links, when I could find a usable link for the target
- Added Pyramid and Flask
- Moved a bunch of frameworks (all those for which I could not see hints of activity in the last 2~3 years, or which were explicitly marked as deprecated) to the deprecated section
- Removed Myghty altogether (it's both deprecated and not a web framework at all)

PS: I just noticed with this page that the wiki seems to make significant use of RST (the frameworks page was already full RST in an rst code block, though not necessarily Sphinx), so porting is significantly easier than expected.
