### PR TITLE
Port the Libraries page

### DIFF
--- a/libraries.rst
+++ b/libraries.rst
@@ -171,9 +171,6 @@ Middleware and libraries for WSGI
     Turns any TurboGears/Buffet template plug-ins into WSGI
     middleware.
 
-`wsgixml <http://uche.ogbuji.net/tech/4suite/wsgixml/>`_
-    WSGI middleware modules for XML processing
-
 `wsgize <http://cheeseshop.python.org/pypi/wsgize/>`_
     WSGI without the WSGI. Provides middleware for WSGI-enabling
     Python callables including:
@@ -215,4 +212,7 @@ deprecated
 `WSGIOverlay <http://pythonpaste.org/wsgioverlay/>`_
     Application-neutral macro templating language. Seems to be
     superseded by Deliverance.
+
+`wsgixml <http://pypi.python.org/pypi/wsgixml/>`_
+    WSGI middleware modules for XML processing
 


### PR DESCRIPTION
Fixed up some deadlink, removed completely disappeared packages, moved some obviously deprecated ones to a dedicated section.

This document probably needs a good review of all packages, at least to check if they're deprecated or unmaintained: over half the packages seem not to have been touched since 2008.
