### PR TITLE
Ported the Presentations page

### DIFF
--- a/presentations.rst
+++ b/presentations.rst
@@ -8,6 +8,10 @@ Videos
 <http://video.google.com/videoplay?docid=-872784530622495809>`_
 (Google TechTalk, 2006, Ben Bangert)
 
+`WSGI: Working together to solve the web's problems
+<http://blip.tv/pycon-us-videos-2009-2010-2011/pycon-2011-wsgi-working-together-to-solve-the-web-s-problems-4895590>`_
+(PyCon 2011, panel)
+
 Slide decks
 -----------
 


### PR DESCRIPTION
Also added the PyCon 2011 WSGI panel, because the URL was lying around.

This page really needs some attention, I'm pretty sure there have been more WSGI-related presentations than these 4.
