### PR TITLE
Werkzeug ref warning

### DIFF
--- a/frameworks.rst
+++ b/frameworks.rst
@@ -94,7 +94,7 @@ unmaintained.
     people like the idea of having found a framework in colubrid. All
     colubrid does for you is parsing form data / url parameters /
     cookies and providing a url dispatcher. Colubrid was replaced by
-    :ref:`werkzeug`.
+    :ref:`Werkzeug <werkzeug-label>`.
 `Nettri <http://code.google.com/p/nettri/>`_
     Nettri is a newcomer of Python World. It is under heavy
     development. Features includes CMS, Own template Engine, modules

--- a/libraries.rst
+++ b/libraries.rst
@@ -182,7 +182,9 @@ Middleware and libraries for WSGI
     * An HTTP response generator
     * A secondary WSGI dispatcher
 
-`Werkzeug <http://werkzeug.pocoo.org/>`_
+.. _werkzeug-label:
+
+ `Werkzeug <http://werkzeug.pocoo.org/>`_
     Werkzeug started as a simple collection of various utilities for
     WSGI applications and has become one of the most advanced WSGI
     utility modules.  It includes a powerful debugger, full featured


### PR DESCRIPTION
Create an explicit label for werkzeug (different from its link-label) so it can be cross-linked from Colubrid's blurb.
