### PR TITLE
Hide copyright and version

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -104,7 +104,7 @@ html_theme = 'nature'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = "WSGI.org"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None


### PR DESCRIPTION
If more specific titling is needed, `html_title` can just be changed to fit. There's also a config key in the HTML session to hide the "Created using Sphinx" stuff (although I don't think that's a big issue)
