### PR TITLE
typo

### DIFF
--- a/what.rst
+++ b/what.rst
@@ -2,7 +2,7 @@ What is WSGI?
 =============
 
 WSGI is the Web Server Gateway Interface. It is a specification that
-describes how web server communicates with web applications, and how
+describes how a web server communicates with web applications, and how
 web applications can be chained together to process one request.
 
 WSGI is Python standard described in detail in :pep:`3333`.


### PR DESCRIPTION
'how web server communicates' was changed to 'how a web server communicates'.
