### PR TITLE
Update information about Zope

### DIFF
--- a/frameworks.rst
+++ b/frameworks.rst
@@ -93,11 +93,11 @@ links!
 `weblayer <http://packages.python.org/weblayer>`_
     weblayer is a lightweight, componentised package for writing WSGI
     applications.
-`Zope 3 <http://www.zope.org/>`_
-    The venerable Python web framework, recreated anew in Zope 3, and
-    now a WSGI application.  It *seems* to have some WSGI bits deep
-    inside the publisher, but they aren't really documented at this
-    time.
+`Zope <https://zope.readthedocs.io>`_
+    The former Zope 2 web application server is now nearing version 4.
+    It now uses WSGI as the default publishing method. A starting
+    configuration using the ``waitress`` WSGI server is included, but all
+    WSGI-compliant servers are supported.
 
 Deprecated Systems
 ------------------
@@ -153,3 +153,9 @@ unmaintained.
     Python Web applications, allowing such applications to run within
     many different environments with virtually no changes to
     application code.
+`Zope 3 <http://www.zope.org/>`_
+    The venerable Python web framework, recreated anew in Zope 3, and
+    now a WSGI application.  It *seems* to have some WSGI bits deep
+    inside the publisher, but they aren't really documented at this
+    time. It is no longer developed as standalone application server, but
+    many of its libraries continue life inside Zope 4.

--- a/frameworks.rst
+++ b/frameworks.rst
@@ -94,10 +94,11 @@ links!
     weblayer is a lightweight, componentised package for writing WSGI
     applications.
 `Zope <https://zope.readthedocs.io>`_
-    The former Zope 2 web application server is now nearing version 4.
-    It now uses WSGI as the default publishing method. A starting
-    configuration using the ``waitress`` WSGI server is included, but all
-    WSGI-compliant servers are supported.
+    The Zope web application server has been using WSGI as the default
+    publishing method starting with version 4. A sample configuration using
+    the ``waitress`` WSGI server is included, but most WSGI-compliant servers
+    are supported.
+
 
 Deprecated Systems
 ------------------
@@ -158,4 +159,4 @@ unmaintained.
     now a WSGI application.  It *seems* to have some WSGI bits deep
     inside the publisher, but they aren't really documented at this
     time. It is no longer developed as standalone application server, but
-    many of its libraries continue life inside Zope 4.
+    many of its libraries continue life inside Zope.

--- a/frameworks.rst
+++ b/frameworks.rst
@@ -95,9 +95,7 @@ links!
     applications.
 `Zope <https://zope.readthedocs.io>`_
     The Zope web application server has been using WSGI as the default
-    publishing method starting with version 4. A sample configuration using
-    the ``waitress`` WSGI server is included, but most WSGI-compliant servers
-    are supported.
+    publishing method starting with version 4.
 
 
 Deprecated Systems


### PR DESCRIPTION
Thank you for including this small update. Zope 3 is no longer maintained, but what was formerly Zope 2 has eveolved into Zope 4 and uses WSGI as its default publishing method.