### PR TITLE
Fix link for `bottle` website

### DIFF
--- a/frameworks.rst
+++ b/frameworks.rst
@@ -25,7 +25,7 @@ links!
 `bobo <http://bobo.digicool.com>`_
   Bobo is a light-weight framework. Its goal is to be easy to use and
   remember.
-`Bottle <http://bottle.paws.de/>`_
+`Bottle <http://bottlepy.org/>`_
     Bottle is a fast and simple micro-framework for small
     web-applications. It offers request dispatching (Routes) with url
     parameter support, Templates, key/value Databases, a build-in HTTP


### PR DESCRIPTION
The previous link seems to be broken. I got the new one from the [official bottle GitHub README](https://github.com/bottlepy/bottle)