### PR TITLE
add item to middlewares list

### DIFF
--- a/libraries.rst
+++ b/libraries.rst
@@ -184,6 +184,15 @@ Middleware and libraries for WSGI
     * An HTTP response generator
     * A secondary WSGI dispatcher
 
+`WSocket <https://github.com/Ksengine/WSocket>`_
+    Simple WSGI HTTP + Websocket Server, Framework, Middleware And App.
+    
+    * Server - Multi threaded WSGI server
+    * Middleware - Add Websocket communicaion to any WSGI framework
+    * Handler - Add Websocket communicaion to wsgiref(python default WSGI server)
+    * Framework -  Websocket WSGI web application framework
+    * App - Event based Websocket serverside app
+
 `yaro <http://pypi.python.org/pypi/yaro>`_
     This distribution provides Yet Another Request Object (for WSGI)
     in a way that is intended to be simple and useful for web


### PR DESCRIPTION
# added [WSocket](https://github.com/Ksengine/wsocket) to list

## Simple WSGI HTTP + Websocket Server, Framework, Middleware And App.

## Includes
- Server(WSGI) included - works with any WSGI framework
- Middleware - adds Websocket support for any  WSGI framework
- Framework - simple Websocket WSGI web application framework
- App - Event based app for Websocket communication
**When external server used some clients like Firefox requires `http 1.1` Server. Middleware, Framework, App**
- Handler - adds Websocket support to [wsgiref](https://docs.python.org/3/library/wsgiref.html "python builtin WSGI server")(python builtin WSGI server)
- Client -Coming soon...

## Common Features

- only single file less than 1000 lines
- websocket sub protocol supported
- websocket message compression supported (works if client asks)
- receive and send pong and ping messages(with automatic pong sender)
- receive and send binary or text messages
- works for messages with or without mask
- closing messages supported
- auto and manual close

## Alternatives
### Non WSGI
- [Autobahn](http://crossbar.io/autobahn/) - huge with extras
- [websocket-client](https://github.com/websocket-client/websocket-client) - client only no server
-[websockets](https://pypi.org/project/websockets/) - python2 not supported

### WSGI
- [Django Channels](https://channels.readthedocs.io/en/stable/) - only for Django. but WSocket middleware can add support for any WSGI framework.
- [Flask-SocketIO](https://flask-socketio.readthedocs.io/en/latest/) - only for Flask.
- [gevent-websocket](https://pypi.org/project/gevent-websocket/) - only for Gevent Server
- [ws4py](https://github.com/Lawouach/WebSocket-for-Python) - works with few servers. but WSocket works with many servers